### PR TITLE
Olympian Stats && Oldest Olympian

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,11 +241,11 @@ HTTP/1.1 200 OK
 ```json
 {
     "olympian_stats": {
-        "total_competing_olympians": 3120,
+        "total_competing_olympians": 2850,
         "average_weight": {
             "unit": "kg",
-            "male_olympians": 75.4,
-            "female_olympians": 70.2
+            "male_olympians": 77,
+            "female_olympians": 60.7
         },
         "average_age": 26.2
     }

--- a/app/controllers/api/v1/olympian_stats_controller.rb
+++ b/app/controllers/api/v1/olympian_stats_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::OlympianStatsController < ApplicationController
+  def index
+    oly_stats = OlympianStatsSerializer.new(OlympianStats.new).serialized_json
+    serialized = JSON.parse(oly_stats)['data']['attributes']
+    render json: { olympian_stats: serialized}
+  end
+end

--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -9,11 +9,4 @@ class  Api::V1::OlympiansController < ApplicationController
       render json: { olympians: Olympian.olympians }
     end
   end
-
-  private
-
-  def olympian_params
-
-    params.require(:olympians).permit(:age)
-  end
 end

--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -2,7 +2,9 @@ class  Api::V1::OlympiansController < ApplicationController
   def index
     case params['age']
     when 'youngest'
-      render json: Olympian.youngest
+      render json: { youngest: Olympian.youngest }
+    when 'oldest'
+      render json: { oldest: Olympian.oldest }
     else
       render json: { olympians: Olympian.olympians }
     end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -8,6 +8,10 @@ class Olympian < ApplicationRecord
   end
 
   def self.youngest
-   [ Olympians.new(self.order(:age).limit(5).first) ] 
+   [ Olympians.new(self.order(:age).limit(5).first) ]
+  end
+  
+  def self.oldest
+   [ Olympians.new(self.order('age DESC').limit(5).first) ]
   end
 end

--- a/app/models/olympian_stats.rb
+++ b/app/models/olympian_stats.rb
@@ -1,0 +1,21 @@
+class OlympianStats
+  attr_reader :id
+  def initialize
+    @id = 1
+  end
+  def total_competing_olympians
+    Olympian.select(:name).distinct.count
+  end
+
+  def average_weight
+    {
+      unit: 'kg',
+      male_olympians:  Olympian.where(sex: 'M').average(:weight).to_f.round(1),
+      female_olympians: Olympian.where(sex: 'F').average(:weight).to_f.round(1)
+    }
+  end
+
+  def average_age
+    Olympian.average(:age).to_f.round(1)
+  end
+end

--- a/app/serializers/olympian_stats_serializer.rb
+++ b/app/serializers/olympian_stats_serializer.rb
@@ -1,0 +1,6 @@
+class OlympianStatsSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :total_competing_olympians,
+             :average_weight,
+             :average_age
+end

--- a/app/serializers/olympians_serializer.rb
+++ b/app/serializers/olympians_serializer.rb
@@ -1,8 +1,0 @@
-class OlympiansSerializer
-  include FastJsonapi::ObjectSerializer
-  attributes :name,
-             :team,
-             :age,
-             :sport,
-             :total_medals_won
-end

--- a/app/serializers/olympians_serializer.rb
+++ b/app/serializers/olympians_serializer.rb
@@ -1,0 +1,8 @@
+class OlympiansSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :name,
+             :team,
+             :age,
+             :sport,
+             :total_medals_won
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :olympians, only: [:index]
+      resources :olympian_stats, only: [:index]
     end
   end
 end

--- a/spec/factories/olympians.rb
+++ b/spec/factories/olympians.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :olympian do
     sequence(:name) { |n| "Name #{n}" }
-    sequence(:sex) { "M" || "W" }
-    sequence(:age) { |n| n }
+    sequence(:sex) { ["M", "F"].sample }
+    sequence(:age) { rand(13..62) }
     sequence(:height) { |n| n }
-    sequence(:weight) { |n| n }
+    sequence(:weight) { rand(55..200) }
     sequence(:team) { |n| "Team #{n}" }
     sequence(:games) { "2020 Games" }
     sequence(:sport) { |n| "Sport #{n}" }

--- a/spec/requests/api/v1/olympian_stats/index_request_spec.rb
+++ b/spec/requests/api/v1/olympian_stats/index_request_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe 'Olympians API Request', type: :request  do
+  before :each do
+    oly2 = create(:olympian, age: 13, sex: 'M', weight: 120)
+    oly3 = create(:olympian, age: 27, sex: 'M', weight: 210)
+    oly4 = create(:olympian, age: 29, sex: 'M', weight: 130)
+    oly5 = create(:olympian, age: 30, sex: 'M', weight: 77)
+    oly6 = create(:olympian, age: 40, sex: 'M', weight: 60)
+    oly6 = create(:olympian, age: 35, sex: 'M', weight: 95)
+    oly7 = create(:olympian, age: 18, sex: 'F', weight: 60)
+    oly8 = create(:olympian, age: 35, sex: 'F', weight: 75)
+    oly9 = create(:olympian, age: 21, sex: 'F', weight: 87)
+    oly10 = create(:olympian, age: 16, sex: 'F', weight: 78)
+    oly11 = create(:olympian, age: 17, sex: 'F', weight: 126)
+    oly12 = create(:olympian, age: 27, sex: 'F', weight: 213)
+    oly13 = create(:olympian, age: 29, sex: 'F', weight: 103)
+    oly14 = create(:olympian, age: 40, sex: 'F', weight: 123)
+    oly15 = create(:olympian, age: 24, sex: 'F', weight: 154)
+  end
+
+  it "in the list of JSON objects I see each objects attributes" do
+    get '/api/v1/olympian_stats'
+
+    expect(response).to be_successful
+
+    olympian = JSON.parse(response.body)['olympian_stats']
+
+    expect(olympian['total_competing_olympians']).to eq(15)
+    expect(olympian['average_weight']['unit']).to eq('kg')
+    expect(olympian['average_weight']['male_olympians']).to eq(115.3)
+    expect(olympian['average_weight']['female_olympians']).to eq(113.2)
+    expect(olympian['average_age']).to eq(26.7)
+  end
+end

--- a/spec/requests/api/v1/olympians/sort_request_spec.rb
+++ b/spec/requests/api/v1/olympians/sort_request_spec.rb
@@ -2,32 +2,59 @@ require "rails_helper"
 
 describe 'Olympians API Request', type: :request  do
   before :each do
-    oly2 = create(:olympian, age: 41)
+    @oly2 = create(:olympian, age: 41, medal: "Gold")
     oly3 = create(:olympian, age: 32)
     @oly1 = create(:olympian, name: "joe", team: "the best", age: 15, sport: "Swimming", event: "swimming 100",  medal: "NA")
     oly4 = create(:olympian, age: 23)
   end
 
-  it "sends a JSON of Olympians that fit the youngest age" do
-    get '/api/v1/olympians?age=youngest'
+  describe 'Youngest' do
+    it "sends a JSON of Olympians that fit the youngest age" do
+      get '/api/v1/olympians?age=youngest'
 
-    expect(response).to be_successful
+      expect(response).to be_successful
 
-    olympians = JSON.parse(response.body)
-    expect(olympians.count).to eq(1)
+      olympians = JSON.parse(response.body)
+      expect(olympians.count).to eq(1)
+    end
+
+    it "in the list of JSON objects I see each objects attributes" do
+      get '/api/v1/olympians?age=youngest'
+
+      expect(response).to be_successful
+
+      olympian = JSON.parse(response.body)['youngest'][0]
+
+      expect(olympian['name']).to eq(@oly1.name)
+      expect(olympian['team']).to eq(@oly1.team)
+      expect(olympian['age']).to eq(@oly1.age)
+      expect(olympian['sport']).to eq(@oly1.sport)
+      expect(olympian['total_medals_won']).to eq(0)
+    end
   end
 
-  it "in the list of JSON objects I see each objects attributes" do
-    get '/api/v1/olympians?age=youngest'
+  describe 'Oldest' do
+    it "sends a JSON of Olympians that fit the youngest age" do
+      get '/api/v1/olympians?age=oldest'
 
-    expect(response).to be_successful
+      expect(response).to be_successful
 
-    olympian = JSON.parse(response.body)[0]
+      olympians = JSON.parse(response.body)
+      expect(olympians.count).to eq(1)
+    end
 
-    expect(olympian['name']).to eq(@oly1.name)
-    expect(olympian['team']).to eq(@oly1.team)
-    expect(olympian['age']).to eq(@oly1.age)
-    expect(olympian['sport']).to eq(@oly1.sport)
-    expect(olympian['total_medals_won']).to eq(0)
+    it "in the list of JSON objects I see each objects attributes" do
+      get '/api/v1/olympians?age=oldest'
+
+      expect(response).to be_successful
+
+      olympian = JSON.parse(response.body)['oldest'][0]
+
+      expect(olympian['name']).to eq(@oly2.name)
+      expect(olympian['team']).to eq(@oly2.team)
+      expect(olympian['age']).to eq(@oly2.age)
+      expect(olympian['sport']).to eq(@oly2.sport)
+      expect(olympian['total_medals_won']).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
Closes #3 
Closes #4 

```
When the client sends a request for the `oldest Olympian`
  It should return the oldest Olympian(s) with attributes
    name
    team
    age
    sport
    total_medals_won
```

```
When the client sends a request for Olympian Stats
  It should return the Olympians total stats
```
- Added the ability to search for the oldest Olympian and can now Get the Olympians Stats. 


#### Required Steps
- [x] Wrote Tests
- [x] Implemented
- [x] Self-Reviewed

#### Neccesary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

#### Type of change
- [x] New feature
- [ ] Bug Fix

#### Check the applicable boxes
- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

#### Testing Changes
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)
__Notes:__

#### Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
